### PR TITLE
Adds profunctor lens and π1 example

### DIFF
--- a/Core/Id.v
+++ b/Core/Id.v
@@ -3,14 +3,14 @@ Require Import Monad.
 Definition Id (A : Type) : Type := A.
 
 Instance Functor_Id : Functor Id :=
-{ fmap _ _ f a := f a }.
+{ fmap A B f a := f a }.
 
 Instance FunctorDec_Id : FunctorDec Id.
 Proof. split; auto. Qed.
 
 Instance Monad_Id : Monad Id :=
-{ ret _ x := x
-; bind _ _ a f := f a
+{ ret A x := x
+; bind A B a f := f a
 }.
 
 Instance MonadDec_Id : MonadDec Id.

--- a/Core/Profunctor.v
+++ b/Core/Profunctor.v
@@ -1,0 +1,42 @@
+Require Import Program.Basics.
+
+Open Scope program_scope.
+
+(* typeclass and laws *)
+
+Class Profunctor (p : Type -> Type -> Type) :=
+{ dimap {A A' B B'} (f : A' -> A) (g : B -> B') : p A B -> p A' B' 
+; lmap {A A' B} (f : A' -> A) : p A B -> p A' B := dimap f id
+; rmap {A B B'} (f : B -> B') : p A B -> p A B' := dimap id f
+}.
+
+Class ProfunctorDec p `{Profunctor p} :=
+{ profunctor_id : forall A B (pab : p A B), dimap id id pab = pab
+; profunctor_comp : forall A A' A'' B B' B'' (pab : p A B)
+                          (f : A'' -> A') (f' : A' -> A) 
+                          (g' : B -> B') (g : B' -> B''),
+    dimap (f' ∘ f) (g ∘ g') pab = (dimap f g ∘ dimap f' g') pab
+}.
+
+(* cartesian profunctor *)
+
+Class Cartesian p `{ProfunctorDec p} :=
+{ first  {A B C} (pab : p A B) : p (prod A C) (prod B C)
+; second {A B C} (pab : p A B) : p (prod C A) (prod C B)
+}.
+
+(* auxiliar defs to define cartesian laws *)
+
+Definition r1  {A} (a1 : prod A unit) : A := fst a1.
+Definition r1' {A} (a: A) : prod A unit := (a, tt).
+
+Definition assoc {A B C} (a_bc : prod A (prod B C)) : prod (prod A B) C :=
+  match a_bc with | pair a (pair b c) => pair (pair a b) c end.
+Definition assoc' {A B C} (ab_c : prod (prod A B) C) : prod A (prod B C) :=
+  match ab_c with | pair (pair a b) c => pair a (pair b c) end.
+
+Class CartesianDec p `{Cartesian p} :=
+{ cartesian_unit : forall A B (h : p A B), dimap r1 r1' h = first h
+; cartesian_assoc : forall A B C (h : p A A), 
+                           dimap assoc assoc' (first (first h)) = @first p _ _ _ A A (prod B C) h
+}.

--- a/Core/Std/fun.v
+++ b/Core/Std/fun.v
@@ -1,0 +1,28 @@
+Require Import Program.Basics.
+Require Import Profunctor.
+Require Import Util.FunExt.
+
+Open Scope program_scope.
+
+Definition Fun (A B : Type) : Type := A -> B.
+
+Instance Profunctor_fun : Profunctor Fun :=
+{ dimap A A' B B' f g ab := g ∘ ab ∘ f
+}.
+
+Instance ProfunctorDec_fun : ProfunctorDec Fun.
+Proof.
+  split; auto.
+Qed.
+
+Instance Cartesian_fun : Cartesian Fun :=
+{ first  A B C f := fun ac => let (a, c) := ac in pair (f a) c
+; second  A B C f := fun ca => let (c, a) := ca in pair c (f a)
+}.
+
+Instance CartesianDec_fun : CartesianDec Fun.
+Proof.
+  split; intros; apply functional_extensionality; intros; destruct x.
+  - now destruct u.
+  - now destruct p.
+Qed.

--- a/Core/Std/option.v
+++ b/Core/Std/option.v
@@ -14,7 +14,7 @@ Definition option_fold {A B} (some : A -> B) (none : B) (oa : option A) : B :=
 (* typeclass instances *)
 
 Instance Functor_option : Functor option :=
-{ fmap _ _ f := option_fold (Some ∘ f) None }.
+{ fmap A B f := option_fold (Some ∘ f) None }.
 
 Instance FunctorDec_option : FunctorDec option.
 Proof.
@@ -22,8 +22,8 @@ Proof.
 Qed.
 
 Instance Monad_option : Monad option :=
-{ ret _ := Some
-; bind _ _ ox f := option_fold f None ox
+{ ret A := Some
+; bind A B ox f := option_fold f None ox
 }.
 
 Instance MonadDec_option : MonadDec option.

--- a/Core/Std/prod.v
+++ b/Core/Std/prod.v
@@ -2,7 +2,7 @@ Require Import Koky.Core.Util.FunExt.
 Require Import Functor.
 
 Instance Functor_prod {A} : Functor (prod A) :=
-{ fmap _ _ f pair := (fst pair, f (snd pair)) }.
+{ fmap A B f pair := (fst pair, f (snd pair)) }.
 
 Instance FunctorDec_prod {A} : FunctorDec (prod A).
 Proof.
@@ -10,7 +10,7 @@ Proof.
 Qed.
 
 Instance Functor_prod' {B} : Functor (fun A => prod A B) :=
-{ fmap _ _ f pair := (f (fst pair), (snd pair)) }.
+{ fmap A B f pair := (f (fst pair), (snd pair)) }.
 
 Instance FunctorDec_prod' {B} : FunctorDec (fun A => prod A B).
 Proof.

--- a/Core/indexedStateT.v
+++ b/Core/indexedStateT.v
@@ -32,7 +32,7 @@ Ltac indexedStateT_reason :=
   end; simpl; auto.
 
 Instance Functor_stateT {S m} `{Monad m} : Functor (stateT S m) :=
-{ fmap _ _ f sa := mkIndexedStateT (fun s =>
+{ fmap A B f sa := mkIndexedStateT (fun s =>
     fmap (fmap f) (runIndexedStateT sa s)) }.
 
 Instance FunctorDec_stateT {S m} `{Monad m} : FunctorDec (stateT S m).
@@ -48,8 +48,8 @@ Proof.
 Qed.
 
 Instance Monad_stateT {S m} `{Monad m} : Monad (stateT S m) :=
-{ ret _ x := mkIndexedStateT (fun s => ret (x, s))
-; bind _ _ sa f := mkIndexedStateT (fun s =>
+{ ret A x := mkIndexedStateT (fun s => ret (x, s))
+; bind A B sa f := mkIndexedStateT (fun s =>
     runIndexedStateT sa s >>= (fun p => runIndexedStateT (f (fst p)) (snd p)))
 }.
 

--- a/Core/lens.v
+++ b/Core/lens.v
@@ -28,8 +28,8 @@ Record lensDec {S A} (ln : lens S A) := mkLensDec
 }.
 
 Instance Category_lens : Category lens :=
-{ identity _ := mkPLens id (fun _ => id) 
-; compose _ _ _ ln1 ln2 := mkPLens 
+{ identity A := mkPLens id (fun _ => id) 
+; compose A B C ln1 ln2 := mkPLens 
     (view ln2 ∘ view ln1)
     (fun s => update ln1 s ∘ update ln2 (view ln1 s))
 }.
@@ -82,6 +82,14 @@ Definition secondDec {A B} : lensDec (@second A B).
 Proof.
   split; simpl; auto.
 Qed.
+
+(** Profunctor lens *)
+
+Require Import Profunctor.
+
+Definition LensP (S T A B : Type) : Type := forall p `{Cartesian p}, p A B -> p S T.
+
+Definition LensP' (S A : Type) : Type := LensP S S A A.
 
 (** Monadic lens *)
 

--- a/Example/plens.v
+++ b/Example/plens.v
@@ -1,0 +1,9 @@
+Require Import Core.lens.
+Require Import Core.Profunctor.
+Require Import Core.Std.fun.
+
+Definition pi1 {A B C} : LensP (prod A C) (prod B C) A B :=
+  fun _ _ _ _ => first.
+
+Example proj_1 : pi1 Fun _ _ _ (fun n => n + 1) (0, 0) = (1, 0).
+Proof. auto. Qed.

--- a/_CoqProject
+++ b/_CoqProject
@@ -8,8 +8,11 @@ Core/lens.v
 Core/Monad.v
 Core/MonadState.v
 Core/naturalTrans.v
+Core/Profunctor.v
+Core/Std/fun.v
 Core/Std/option.v
 Core/Std/prod.v
 Core/Std/sum.v
 Core/Util/FunExt.v
 Example/mlens.v
+Example/plens.v


### PR DESCRIPTION
Adds `Profunctor` definition (along with `Cartesian`) and defines a profunctor lens, providing a simple example that projects the first component of a product, by means of the function profunctor.